### PR TITLE
fix: year dropdown for monthly stats

### DIFF
--- a/plugins/usage-statistics-backend/package.json
+++ b/plugins/usage-statistics-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeverse-gp/plugin-usage-statistics-backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A backend plugin for tracking and displaying usage statistics in Backstage.",
   "license": "MIT",
   "main": "src/index.ts",

--- a/plugins/usage-statistics/package.json
+++ b/plugins/usage-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeverse-gp/plugin-usage-statistics",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A plugin for tracking and displaying usage statistics in Backstage.",
   "license": "MIT",
   "main": "src/index.ts",

--- a/plugins/usage-statistics/src/components/Templates/TemplateMonthlyStatsCard/TemplateMonthlyStatsCard.tsx
+++ b/plugins/usage-statistics/src/components/Templates/TemplateMonthlyStatsCard/TemplateMonthlyStatsCard.tsx
@@ -51,7 +51,6 @@ export const CustomTooltip = (props: any) => {
   );
 };
 
-
 export const TemplateMonthlyStatsCard = () => {
   const { entity } = useEntity();
   const templateName = entity.metadata.name;
@@ -59,13 +58,17 @@ export const TemplateMonthlyStatsCard = () => {
     useMonthlyStatsByTemplateName(templateName);
 
   const allStats = monthlyStats || [];
+  const currentYear = new Date().getFullYear().toString();
   const years = Array.from(
     new Set(allStats.map(stat => stat.month.slice(0, 4))),
   )
     .sort()
     .reverse();
-  const currentYear = new Date().getFullYear().toString();
-  const [selectedYear, setSelectedYear] = useState<string>(currentYear);
+
+  const initialYear = years.includes(currentYear)
+    ? currentYear
+    : years[0] || currentYear;
+  const [selectedYear, setSelectedYear] = useState<string>(initialYear);
 
   const filteredStats = allStats.filter(stat =>
     stat.month.startsWith(selectedYear),
@@ -113,21 +116,19 @@ export const TemplateMonthlyStatsCard = () => {
         </Select>
       </FormControl>
       <ResponsiveContainer width="100%" height={300}>
-        
-          <BarChart
-            data={filteredStats}
-            margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" />
-            <YAxis allowDecimals={false} />
-            <Tooltip content={<CustomTooltip />} />
-            <Legend />
-            <Bar dataKey="success" fill="#4caf50" name="Success" />
-            <Bar dataKey="failed" fill="#f44336" name="Failed" />
-            <Bar dataKey="total" fill="#8884d8" name="Total" />
-          </BarChart>
-        
+        <BarChart
+          data={filteredStats}
+          margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis allowDecimals={false} />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend />
+          <Bar dataKey="success" fill="#4caf50" name="Success" />
+          <Bar dataKey="failed" fill="#f44336" name="Failed" />
+          <Bar dataKey="total" fill="#8884d8" name="Total" />
+        </BarChart>
       </ResponsiveContainer>
     </InfoCard>
   );


### PR DESCRIPTION
This pull request refines the `TemplateMonthlyStatsCard` component in the `plugins/usage-statistics` package by improving the logic for selecting the initial year and cleaning up unnecessary whitespace in the code.

### Improvements to year selection logic:
* Refactored the initialization of the `selectedYear` state to handle cases where the current year is not present in the data. The `initialYear` now defaults to the first available year in the dataset or the current year if no data exists. (`[plugins/usage-statistics/src/components/Templates/TemplateMonthlyStatsCard/TemplateMonthlyStatsCard.tsxL54-R71](diffhunk://#diff-e5d3000dcd4c7a051e9e5b1c689cd9ffdfece608906f17d5ed7ab5f266c484f4L54-R71)`)
